### PR TITLE
Sign In Modal, Remove Item, List Validation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -132,6 +132,7 @@ $(document).on('turbolinks:load', function() {
     });
 
     function launchSignInWithCallback(callback) {
+        $(document).off('sign_in');
         launchSignInModal();
         //on sign-in, perform callback
         $(document).on('sign_in', function (e) {

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -179,24 +179,21 @@ class ListsController < ApplicationController
   def remove_item
 	  @item_id = params[:item_id]
 	  @list_id = params[:list_id]
-	  @lists = available_collections()
+	  
+    @list = get_collection_by_id(@list_id)
 
 	  #validate that user owns list
-	  list_found = false
-	  @lists.each do |x|
-		  if x['id'].to_s == @list_id.to_s
-			  list_found = true
-			  break
-		  end
-	  end
-
-	  if !list_found
+	  if @list.nil? || @list.count == 0
 	  	redirect_to '/lists'
 		  return
 	  end
 
-      @deleted_items = delete_item_from_collection(current_or_guest_user.api_key, @list_id, @item_id)
-
+    @deleted_items = delete_item_from_collection(current_or_guest_user.api_key, @list_id, @item_id)
+    
+    #perform search on the list to get latest results on next load
+    search_params = {}
+	  search_params[:setSpec] = @list[0]['setSpec']
+    (@response, @document_list) = search_results(search_params)
 	  redirect_to '/lists/' + @list_id
 	end
 


### PR DESCRIPTION
### Sign In modal
Changed to only allow one pending action when logged out.

As a logged out user, click on an item to add to a list, close the sign in modal without signing in, click on another item to add, then sign in. Prior to the fix, you can see the Add Item modal load multiple times on slower environments. After the fix, only the last item should load in the modal.

### Remove Item
Changed to perform a search on user's list after removing and before redirecting to the list page.

Prior to the fix, the list would still include the removed item. After the fix, the removed item should not appear in the results on redirect.

### List Validation
Changed the show, add_items, and remove_item methods to use get_collection_by_id instead of available_collections to check if the user owns the list.
